### PR TITLE
docs: clarify Node.js/npm prerequisites in front-end README

### DIFF
--- a/front-end/README.md
+++ b/front-end/README.md
@@ -1,56 +1,53 @@
-Front-end (Vite + React)
+# Front-end (Vite + React)
 
-Quick start
+## Prerequisites
 
-1) From the repo root, go to the front-end folder
+- [Node.js](https://nodejs.org/) 18+ and npm installed.  
+  If you use `nvm`:
+  ```sh
+  nvm use 18 || nvm install 18
+  ```
 
-```sh
-cd front-end
-```
+## Quick start
 
-2) Install dependencies
+1. From the repo root, go to the front-end folder:
 
-```sh
-npm install
-```
+   ```sh
+   cd front-end
+   ```
 
-3) Start the dev server (opens your browser)
+2. Install dependencies:
 
-```sh
-npm run dev
-```
+   ```sh
+   npm install
+   ```
 
-By default the app runs at http://localhost:4000 (see `vite.config.js`).
+3. Start the dev server (opens your browser):
+   ```sh
+   npm run dev
+   ```
+   By default the app runs at http://localhost:4000 (see `vite.config.js`).
 
-Other scripts
+## Other scripts
 
-- Build for production
+- Build for production:
 
-```sh
-npm run build
-```
+  ```sh
+  npm run build
+  ```
 
-- Preview the production build locally
+- Preview the production build locally:
 
-```sh
-npm run preview
-```
+  ```sh
+  npm run preview
+  ```
 
-- Lint the code
+- Lint the code:
+  ```sh
+  npm run lint
+  ```
 
-```sh
-npm run lint
-```
+## Troubleshooting
 
-Prerequisites
-
-- Node.js 18+ and npm installed. If you use nvm:
-
-```sh
-nvm use 18 || nvm install 18
-```
-
-Troubleshooting
-
-- “npm run dev not found”: ensure you are inside the `front-end` folder and ran `npm install`.
+- “npm run dev not found”: ensure you are inside the `front-end` folder **and** have run `npm install`.
 - Port in use: the dev server uses port 4000. Update `server.port` in `vite.config.js` or free the port.


### PR DESCRIPTION
### Summary
This PR moves the Node.js/npm prerequisite from the bottom of the front-end README to the top (under "Prerequisites"), where it’s easier for new contributors to see before running `npm install`.

### Why
- Currently, the prerequisite is included but buried after "Other scripts" and "Troubleshooting".
- New contributors may miss it, leading to `npm` errors on first setup.
- This change improves readability and onboarding without altering content.
- Gives me my first contribution on the project

### Changes
- Reorganized README sections:
  - Added "Prerequisites" at the top.
  - Adjusted Quick start steps accordingly.
  - Kept all existing content intact.