### PR TITLE
chore(front-end): set up GitHub Pages deploy via Actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,59 @@
+name: Deploy front-end to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "front-end/**"
+      - ".github/workflows/deploy-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: front-end/package-lock.json
+
+      - name: Install deps
+        working-directory: front-end
+        run: npm ci
+
+      - name: Build
+        working-directory: front-end
+        env:
+          CI: true
+        run: |
+          npm run build
+          # SPA fallback (safe even if you’re not routing yet)
+          cp dist/index.html dist/404.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: front-end/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/front-end/vite.config.js
+++ b/front-end/vite.config.js
@@ -1,8 +1,9 @@
+/* eslint-env node */
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: "/proj-green-careers-map/", // GitHub Pages project path
   server: { port: 4000 },
 });


### PR DESCRIPTION
### Why
Implements ticket: https://github.com/CivicTechAtlanta/proj-green-careers-map/issues/11  
Publishes the React front-end (in /front-end) to GitHub Pages using GitHub Actions.

### What changed
- Added `.github/workflows/deploy-pages.yml` to build only the front-end and upload `front-end/dist` as the Pages artifact.
- Set Vite `base` to `/proj-green-careers-map/` so static assets resolve correctly on project pages.

### Notes
- If API env vars are needed, maintainers can add them to the Build step via `env:` (e.g. `VITE_API_BASE_URL`).
- Pages must be enabled in repo **Settings → Pages → Source: GitHub Actions**.